### PR TITLE
Add standalone script for e2e testing

### DIFF
--- a/jvm/ml4ir-inference/src/main/java/ml4ir/inference/e2e.java
+++ b/jvm/ml4ir-inference/src/main/java/ml4ir/inference/e2e.java
@@ -1,0 +1,69 @@
+package ml4ir.inference;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.GeneratedMessageV3;
+import ml4ir.inference.tensorflow.ModelExecutorConfig;
+import ml4ir.inference.tensorflow.TFRecordExecutor;
+import ml4ir.inference.tensorflow.data.ModelFeaturesConfig;
+import ml4ir.inference.tensorflow.data.SequenceExampleBuilder;
+import ml4ir.inference.tensorflow.data.StringMapSequenceExampleBuilder;
+import org.tensorflow.example.FeatureList;
+import org.tensorflow.example.SequenceExample;
+
+import java.util.List;
+import java.util.Map;
+
+public class e2e {
+
+    private static final String FEATURE_CONFIG = "python/feature_config_test_e2e.yaml";
+    private static final String DATASET = "python/TEST_DIR/validation/validation.csv";
+    private static final String MODEL = "python/models/e2e_run/final/tfrecord";
+
+    public static void main(String[] args) {
+        final String PROJECT_DIR = args[0];
+
+        Map<String, String> contextMap = ImmutableMap.of("query_id", "q00");
+        List<Map<String, String>> documents = ImmutableList.of(
+                ImmutableMap.of(
+                        "feature1", "474",
+                        "feature2", "0.39254769476227647",
+                        "feature3", "wibdifgefxkzluocsrwerwixmzutpwgfw"
+                ),
+                ImmutableMap.of(
+                        "feature1", "339",
+                        "feature2", "0.9993560517954271",
+                        "feature3", "qzwjdmiwtiqlxwywajtfcyouxssuoccdyskalhyhrdhztfyhh"
+                )
+        );
+        ModelFeaturesConfig modelFeatures = ModelFeaturesConfig.load(PROJECT_DIR + FEATURE_CONFIG);
+
+        SequenceExampleBuilder<Map<String, String>, Map<String, String>> sequenceExampleBuilder =
+                StringMapSequenceExampleBuilder.withFeatureProcessors(
+                        modelFeatures,
+                        ImmutableMap.of(),  // No processing for int, float or string
+                        ImmutableMap.of(),
+                        ImmutableMap.of());
+
+        SequenceExample sequenceExample = sequenceExampleBuilder.build(contextMap, documents);
+
+
+        ModelExecutorConfig modelConfig = new ModelExecutorConfig("serving_tfrecord_protos",
+                "StatefulPartitionedCall");
+        TFRecordExecutor bundleExecutor = new TFRecordExecutor(PROJECT_DIR + MODEL, modelConfig);
+
+        Map<String, FeatureList> featureListMap = sequenceExample.getFeatureLists().getFeatureListMap();
+
+        List<Long> feature1 =
+                featureListMap.get("feature1").getFeatureList().get(0).getInt64List().getValueList();
+
+        List<Float> feature2 =
+                featureListMap.get("feature2").getFeatureList().get(0).getFloatList().getValueList();
+
+        float[] predictions = bundleExecutor.apply(sequenceExample);
+
+        System.out.println(predictions);
+
+    }
+
+}

--- a/python/dataset_generator.py
+++ b/python/dataset_generator.py
@@ -8,7 +8,7 @@ def get_random_string(length):
     return result_str
 
 
-def generate_csv_file(path, sequence_length=100):
+def generate_csv_file(path, sequence_length=5000):
     '''
     Generate a random data set that fit the feature_config_test_e2e.yaml feature config format.
     This is to train dummy ranking model for validation purpose.
@@ -18,15 +18,16 @@ def generate_csv_file(path, sequence_length=100):
     with open(path, mode='w') as input:
         # feature1 is an int64, feature2 a float and feature3 a string
         # NOTE: discard feature3 from training from now, as it fails to be parsed
-        input.write('"query_id","rank","feature1","feature2","feature3","label"\n')
+        input.write('"query_id","query_str","rank","feature1","feature2","feature3","label"\n')
 
         for query in range(sequence_length):
             rank = 0
+            query_string = get_random_string(8)
             for i in range(random.randint(1, 6)):
                 rank += 1
-                input.write('"{}",{},{},{},"{}",{}\n'.
-                            format("q" + str(query).zfill(2), rank, random.randint(1,999),
-                                   random.random(), get_random_string(random.randint(4,50)),
+                input.write('"{}","{}",{},{},{},"{}",{}\n'.
+                            format("q" + str(query).zfill(2), query_string, rank, random.randint(1,999),
+                                   random.random(), get_random_string(random.randint(4,20)),
                                    1 if rank == 1 else 0))
 
 

--- a/python/dataset_generator.py
+++ b/python/dataset_generator.py
@@ -1,0 +1,34 @@
+import random
+import string
+
+
+def get_random_string(length):
+    letters = string.ascii_lowercase
+    result_str = ''.join(random.choice(letters) for i in range(length))
+    return result_str
+
+
+def generate_csv_file(path, sequence_length=100):
+    '''
+    Generate a random data set that fit the feature_config_test_e2e.yaml feature config format.
+    This is to train dummy ranking model for validation purpose.
+
+    @param sequence_length: number of sequence to generate
+    '''
+    with open(path, mode='w') as input:
+        # feature1 is an int64, feature2 a float and feature3 a string
+        # NOTE: discard feature3 from training from now, as it fails to be parsed
+        input.write('"query_id","rank","feature1","feature2","feature3","label"\n')
+
+        for query in range(sequence_length):
+            rank = 0
+            for i in range(random.randint(1, 6)):
+                rank += 1
+                input.write('"{}",{},{},{},"{}",{}\n'.
+                            format("q" + str(query).zfill(2), rank, random.randint(1,999),
+                                   random.random(), get_random_string(random.randint(4,50)),
+                                   1 if rank == 1 else 0))
+
+
+if __name__ == "__main__":
+    generate_csv_file("test.csv")

--- a/python/feature_config_test_e2e.yaml
+++ b/python/feature_config_test_e2e.yaml
@@ -1,0 +1,80 @@
+query_key:
+  name: query_id
+  node_name: query_id
+  trainable: false
+  dtype: string
+  log_at_inference: true
+  feature_layer_info:
+    type: numeric
+    shape: null
+  serving_info:
+    name: queryId
+    required: false
+    default_value: ""
+  tfrecord_type: context
+rank:
+  name: rank
+  node_name: rank
+  trainable: false
+  dtype: int64
+  log_at_inference: true
+  feature_layer_info:
+    type: numeric
+    shape: null
+  serving_info:
+    name: originalRank
+    required: false
+    default_value: 0
+  tfrecord_type: sequence
+label:
+  name: label
+  node_name: label
+  trainable: false
+  dtype: int64
+  log_at_inference: true
+  feature_layer_info:
+    type: numeric
+    shape: null
+  serving_info:
+    name: label
+    required: false
+    default_value: 0
+  tfrecord_type: sequence
+features:
+  - name: feature1
+    node_name: feature1
+    trainable: true
+    dtype: int64
+    log_at_inference: false
+    feature_layer_info:
+      type: numeric
+      shape: null
+    serving_info:
+      name: feature1
+      required: true
+      default_value: 0
+    tfrecord_type: sequence
+  - name: feature2
+    node_name: feature2
+    trainable: true
+    dtype: float
+    log_at_inference: false
+    feature_layer_info:
+      type: numeric
+      shape: null
+    serving_info:
+      name: feature2
+      required: true
+      default_value: 0.0
+    tfrecord_type: sequence
+  - name: query_id
+    node_name: query_id
+    trainable: false
+    dtype: string
+    log_at_inference: true
+    serving_info:
+      name: query_id
+      required: true
+      default_value: ""
+    tfrecord_type: context
+

--- a/python/feature_config_test_e2e.yaml
+++ b/python/feature_config_test_e2e.yaml
@@ -5,7 +5,8 @@ query_key:
   dtype: string
   log_at_inference: true
   feature_layer_info:
-    type: numeric
+    type: string
+    max_length: 20
     shape: null
   serving_info:
     name: queryId
@@ -22,7 +23,7 @@ rank:
     type: numeric
     shape: null
   serving_info:
-    name: originalRank
+    name: rank
     required: false
     default_value: 0
   tfrecord_type: sequence
@@ -67,14 +68,17 @@ features:
       required: true
       default_value: 0.0
     tfrecord_type: sequence
-  - name: query_id
-    node_name: query_id
+  - name: query_str
+    node_name: query_str
     trainable: false
     dtype: string
     log_at_inference: true
+    feature_layer_info:
+      type: numeric
+      max_length: 20
+      shape: null
     serving_info:
-      name: query_id
+      name: query_str
       required: true
-      default_value: ""
     tfrecord_type: context
 

--- a/python/run_prediction.py
+++ b/python/run_prediction.py
@@ -1,0 +1,51 @@
+import os
+
+import dataset_generator
+from ml4ir.applications.ranking.config.parse_args import RankingArgParser
+from ml4ir.applications.ranking.pipeline import RankingPipeline
+from ml4ir.base.model.relevance_model import RelevanceModel
+
+TEST_DIRECTORY = "TEST_DIR"
+TEST_FEATURE_CONFIG = "feature_config_test_e2e.yaml"
+
+
+def generate_ranking_model(data_path, feature_config):
+    rp = RankingPipeline(RankingArgParser().parse_args([
+        "--data_dir", data_path,
+        "--feature_config", feature_config,
+        "--run_id", "e2e_run",
+        "--data_format", "csv",
+         "--execution_mode", "train_only",
+        "--batch_size", "32",
+    ]))
+    rp.run()
+    return rp.get_relevance_model(), rp.get_relevance_dataset().validation
+
+
+def do_predict(relevance_model: RelevanceModel, dataset) -> object:
+
+    os.makedirs("e2e_python_predict", exist_ok=True)
+    relevance_model.predict(dataset, logs_dir= "e2e_python_predict")
+
+
+if __name__ == "__main__":
+    """
+    Script to :
+        - create a random dataset to train in a Ranking Pipeline.
+        - execute the default Ranking Pipeline training on it
+        - do and log prediction file on a validation set to be able to compare with Java execution of the model
+    """
+    if not os.path.exists(TEST_DIRECTORY):
+        # TODO? : create 3 dataset {test, train, validation} to avoid execution errors (only need train)
+        os.makedirs(TEST_DIRECTORY + "/test")
+        os.makedirs(TEST_DIRECTORY + "/train")
+        os.makedirs(TEST_DIRECTORY + "/validation")
+        dataset_generator.generate_csv_file(TEST_DIRECTORY + "/test/test.csv")
+        dataset_generator.generate_csv_file(TEST_DIRECTORY + "/train/train.csv")
+        # TODO? : limit the validation data to 5ish. From my experience, if a minimal amount of data is not there
+        #         the predictions_file is not generated (even when reducing the log_frequency)
+        dataset_generator.generate_csv_file(TEST_DIRECTORY + "/validation/validation.csv")
+
+    model, validation_dataset = generate_ranking_model(TEST_DIRECTORY, TEST_FEATURE_CONFIG)
+
+    do_predict(model, validation_dataset)


### PR DESCRIPTION
Add 2 scripts that:
 - Allows to generate fake training data, train a model a do prediction
   in python
 - Run the generated model within the JVM to compare the output.